### PR TITLE
Link to CoinUtils.lib only; remove direct MKL linkage in Cbc build #23

### DIFF
--- a/recipe/build_package.sh
+++ b/recipe/build_package.sh
@@ -13,7 +13,7 @@ if [[ "${target_platform}" == win-* ]]; then
   CLP_INC=( --with-clp-incdir='${LIBRARY_PREFIX_COIN}' )
   COINDEPEND_LIB=( --with-coindepend-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib ${LIBRARY_PREFIX}/lib/libOsi.lib ${LIBRARY_PREFIX}/lib/libCgl.lib' )
   COINDEPEND_INC=( --with-coindepend-incdir='${LIBRARY_PREFIX_COIN}' )
-  EXTRA_FLAGS=( --enable-msvc=MD ) 
+  EXTRA_FLAGS=( --enable-msvc=MD )
 else
   # Get an updated config.sub and config.guess (for mac arm and lnx aarch64)
   cp $BUILD_PREFIX/share/gnuconfig/config.* ./Cbc 

--- a/recipe/build_package.sh
+++ b/recipe/build_package.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  CLP_LIB=( --with-clp-lib='${LIBRARY_PREFIX}/lib/libClp.lib ${LIBRARY_PREFIX}/lib/libOsiClp.lib' )
+  CLP_LIB=( --with-clp-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libClp.lib ${LIBRARY_PREFIX}/lib/libOsiClp.lib' )
   CLP_INC=( --with-clp-incdir='${LIBRARY_PREFIX_COIN}' )
   COINDEPEND_LIB=( --with-coindepend-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib ${LIBRARY_PREFIX}/lib/libOsi.lib ${LIBRARY_PREFIX}/lib/libCgl.lib' )
   COINDEPEND_INC=( --with-coindepend-incdir='${LIBRARY_PREFIX_COIN}' )

--- a/recipe/build_package.sh
+++ b/recipe/build_package.sh
@@ -11,7 +11,7 @@ fi
 if [[ "${target_platform}" == win-* ]]; then
   CLP_LIB=( --with-clp-lib='${LIBRARY_PREFIX}/lib/libClp.lib ${LIBRARY_PREFIX}/lib/libOsiClp.lib' )
   CLP_INC=( --with-clp-incdir='${LIBRARY_PREFIX_COIN}' )
-  COINDEPEND_LIB=( --with-coindepend-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib ${LIBRARY_PREFIX}/lib/libOsi.lib ${LIBRARY_PREFIX}/lib/libCgl.lib' )
+  COINDEPEND_LIB=( --with-coindepend-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib ${LIBRARY_PREFIX}/lib/libOsi.lib ${LIBRARY_PREFIX}/lib/libCgl.lib' )
   COINDEPEND_INC=( --with-coindepend-incdir='${LIBRARY_PREFIX_COIN}' )
   EXTRA_FLAGS=( --enable-msvc=MD ) 
 else

--- a/recipe/build_package.sh
+++ b/recipe/build_package.sh
@@ -9,9 +9,9 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  CLP_LIB=( --with-clp-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libClp.lib ${LIBRARY_PREFIX}/lib/libOsiClp.lib' )
+  CLP_LIB=( --with-clp-lib='${LIBRARY_PREFIX}/lib/libClp.lib ${LIBRARY_PREFIX}/lib/libOsiClp.lib' )
   CLP_INC=( --with-clp-incdir='${LIBRARY_PREFIX_COIN}' )
-  COINDEPEND_LIB=( --with-coindepend-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib ${LIBRARY_PREFIX}/lib/libOsi.lib ${LIBRARY_PREFIX}/lib/libCgl.lib' )
+  COINDEPEND_LIB=( --with-coindepend-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib ${LIBRARY_PREFIX}/lib/libOsi.lib ${LIBRARY_PREFIX}/lib/libCgl.lib' )
   COINDEPEND_INC=( --with-coindepend-incdir='${LIBRARY_PREFIX_COIN}' )
   EXTRA_FLAGS=( --enable-msvc=MD )
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ outputs:
         - coin-or-clp
         - coin-or-osi
         - coin-or-utils
+        - mkl-devel  # [win]
         - zlib
         - bzip2      
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ outputs:
         - coin-or-clp
         - coin-or-osi
         - coin-or-utils
-        - mkl-devel  # [win]
         - zlib
         - bzip2      
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,12 +41,6 @@ outputs:
         - coin-or-clp
         - coin-or-osi
         - coin-or-utils
-        - blas-devel
-        - libblas  # [unix]
-        - libcblas
-        - liblapack
-        - liblapacke  # [unix]
-        - mkl-devel  # [win]
         - zlib
         - bzip2      
       run_constrained:


### PR DESCRIPTION
CoinUtils is already linked against MKL during its own build process.
Cbc itself does not make direct BLAS/LAPACK or MKL calls.
Therefore, explicitly passing MKL libraries during Cbc's build is unnecessary and may lead to unresolved symbols or linking conflicts.